### PR TITLE
checkout branch from main, force push to docs

### DIFF
--- a/.github/workflows/dbt_docs_updates.yml
+++ b/.github/workflows/dbt_docs_updates.yml
@@ -31,15 +31,13 @@ jobs:
         run: |
           pip install dbt-snowflake
           dbt deps
-      - name: delete existing docs branch
-        run: git push origin --delete docs || true
 
       - name: checkout docs branch
         run: |
-          git checkout -b docs
-          git push --set-upstream origin docs
+          git checkout -B docs origin/main
+
       - name: generate dbt docs
-        run: dbt docs generate -t prod --profiles-dir ./.dbt
+        run: dbt docs generate -t prod
 
       - name: move files to docs directory
         run: |
@@ -61,4 +59,4 @@ jobs:
           git commit -am "Auto-update docs"
       - name: push changes to docs
         run: |
-          git push
+          git push -f --set-upstream origin docs


### PR DESCRIPTION
- Current template makes it so the GH pages configuration is reset because it deletes the branch before making the new docs.  This changes it to keep the existing branch on an update