### PR TITLE
Make python runtime configurable

### DIFF
--- a/.github/workflows/dbt_run_template.yml
+++ b/.github/workflows/dbt_run_template.yml
@@ -41,7 +41,7 @@ jobs:
 
       - uses: actions/setup-python@v1
         with:
-          python-version: "3.7.x"
+          python-version: "3.8.x"
 
       - name: overwrite env vars
         if: ${{ env.USE_VARS == 'TRUE' }}

--- a/.github/workflows/dbt_run_template.yml
+++ b/.github/workflows/dbt_run_template.yml
@@ -15,6 +15,11 @@ on:
         type: string
         description: 'dbt warehouse'
         required: true
+      python_version:
+        type: string
+        description: 'python version'
+        required: true
+        default: "3.7.x"
 
 env:
   USE_VARS: "${{ vars.USE_VARS }}"
@@ -41,7 +46,7 @@ jobs:
 
       - uses: actions/setup-python@v1
         with:
-          python-version: "3.8.x"
+          python-version: ${{ inputs.python_version }}
 
       - name: overwrite env vars
         if: ${{ env.USE_VARS == 'TRUE' }}


### PR DESCRIPTION
Makes python version for reusable `dbt workflow` configurable via input params, defaults to existing `3.7.x` 