### PR TITLE
bump actions/upload-artifact -> v4

### DIFF
--- a/.github/workflows/dbt.yml
+++ b/.github/workflows/dbt.yml
@@ -58,7 +58,7 @@ jobs:
         run: |
           ${{ inputs.command }}
       - name: Store logs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: dbt-logs
           path: |


### PR DESCRIPTION
- Bumps [depecated](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/) `actions/upload-artifact@v3` -> `v4`

[GHA failure](https://github.com/FlipsideCrypto/klaytn-models/actions/runs/13248998034/job/36982196945) using this workflow template 