### PR TITLE
Add retry logic for checkout and setup-python steps

### DIFF
--- a/.github/workflows/dbt_run_selfhosted_template.yml
+++ b/.github/workflows/dbt_run_selfhosted_template.yml
@@ -72,8 +72,29 @@ jobs:
         run: echo "started=true" >> $GITHUB_OUTPUT
 
       - uses: actions/checkout@v3
+        id: checkout
+        continue-on-error: true
+
+      - name: Wait before checkout retry
+        if: steps.checkout.outcome == 'failure'
+        run: sleep 15
+
+      - uses: actions/checkout@v3
+        if: steps.checkout.outcome == 'failure'
 
       - uses: actions/setup-python@v4
+        id: setup-python
+        continue-on-error: true
+        with:
+          python-version: "3.10"
+          cache: "pip"
+
+      - name: Wait before setup-python retry
+        if: steps.setup-python.outcome == 'failure'
+        run: sleep 15
+
+      - uses: actions/setup-python@v4
+        if: steps.setup-python.outcome == 'failure'
         with:
           python-version: "3.10"
           cache: "pip"
@@ -99,8 +120,29 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+        id: checkout-fallback
+        continue-on-error: true
+
+      - name: Wait before checkout retry
+        if: steps.checkout-fallback.outcome == 'failure'
+        run: sleep 15
+
+      - uses: actions/checkout@v3
+        if: steps.checkout-fallback.outcome == 'failure'
 
       - uses: actions/setup-python@v4
+        id: setup-python-fallback
+        continue-on-error: true
+        with:
+          python-version: "3.10"
+          cache: "pip"
+
+      - name: Wait before setup-python retry
+        if: steps.setup-python-fallback.outcome == 'failure'
+        run: sleep 15
+
+      - uses: actions/setup-python@v4
+        if: steps.setup-python-fallback.outcome == 'failure'
         with:
           python-version: "3.10"
           cache: "pip"


### PR DESCRIPTION
## Summary
- Adds retry-with-backoff for `actions/checkout` and `actions/setup-python` in both the primary self-hosted job and the `ubuntu-latest` fallback job
- Pattern: first attempt with `continue-on-error: true` → 15s sleep → conditional retry on failure
- Targets the two most common transient infrastructure failure points

## Test plan
- [ ] Trigger a caller workflow to verify the happy path (all steps pass on first attempt, retries are skipped)
- [ ] Verify in workflow logs that retry steps show as "skipped" on success
- [ ] Monitor next few scheduled runs for any regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)