### PR TITLE
chore: migrate to data-platform-prod ARC runners

### DIFF
--- a/.github/workflows/dbt_run_selfhosted_template.yml
+++ b/.github/workflows/dbt_run_selfhosted_template.yml
@@ -16,7 +16,7 @@ on:
         type: string
         description: 'self-hosted runner label'
         required: false
-        default: 'cluster-ops-prod'
+        default: 'data-platform-prod'
       timeout_minutes:
         type: number
         description: 'timeout for the dbt job in minutes'
@@ -26,7 +26,7 @@ on:
         type: string
         description: 'container image for self-hosted runner'
         required: false
-        default: 'ghcr.io/catthehacker/ubuntu:act-latest'
+        default: '924682671219.dkr.ecr.us-east-1.amazonaws.com/data-platform-eks-prod/ci-runner:latest'
       warehouse:
         type: string
         description: 'override warehouse (defaults to vars.WAREHOUSE)'
@@ -71,12 +71,7 @@ jobs:
         id: mark-started
         run: echo "started=true" >> $GITHUB_OUTPUT
 
-      - uses: actions/checkout@v3
-
-      - uses: actions/setup-python@v4
-        with:
-          python-version: "3.10"
-          cache: "pip"
+      - uses: actions/checkout@v6
 
       - name: Configure git for internal repos
         run: git config --global url."https://x-access-token:${{ secrets.GH_INTERNAL_TOKEN }}@github.com/".insteadOf "https://github.com/"
@@ -98,7 +93,7 @@ jobs:
       name: ${{ inputs.environment }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
 
       - uses: actions/setup-python@v4
         with:


### PR DESCRIPTION
## Summary
- Default runner: `cluster-ops-prod` → `data-platform-prod`
- Default container image: `ghcr.io/catthehacker/ubuntu:act-latest` → `ci-runner:latest`
- Remove `actions/setup-python` from self-hosted job (python3+pip baked into ci-runner image)
- Bump `actions/checkout` v3 → v6
- Fallback job (`ubuntu-latest`) unchanged — still uses `setup-python`

## Test plan
- [ ] Trigger a dbt workflow that uses this template and verify it runs on `data-platform-prod`
- [ ] Verify `pip install` works without `setup-python` in the ci-runner container
- [ ] Verify fallback job still works on `ubuntu-latest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)